### PR TITLE
add node docker compose 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,7 +3,7 @@ APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
 APP_TIMEZONE=UTC
-APP_URL=http://localhost
+APP_URL=http://localhost:8080
 
 APP_LOCALE=en
 APP_FALLBACK_LOCALE=en

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - ./:/var/www/html:delegated
     depends_on:
       - mysql
+      - node
     networks:
       - zona-network
 
@@ -40,6 +41,18 @@ services:
       - zona-network
     volumes:
       - mysql:/var/lib/mysql
+
+  node:
+    container_name: zona-node
+    image: node:20
+    working_dir: /home/node/app
+    volumes:
+      - ./:/home/node/app
+    command: ["sh", "-c", "npm install && npm run dev"]
+    ports:
+      - "5173:5173"
+    networks:
+      - zona-network
 
 networks:
   zona-network:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "Zona",
+    "name": "app",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,7 +20,16 @@ export default defineConfig({
     },
   },
   server: {
+    host: '0.0.0.0',
     port: 5173,
+    hmr: {
+      host: 'localhost',
+      port: 5173,
+    },
+    watch: {
+      usePolling: true,
+      interval: 100, 
+  },
     proxy: {
       '/api': {
         target: 'http://localhost:8000',


### PR DESCRIPTION
integrate the frontend part into the docker compose service so its starts along with the other service and dont relies on an separate command `npm run dev`